### PR TITLE
Add category to question display 

### DIFF
--- a/src/pages/question/question.html
+++ b/src/pages/question/question.html
@@ -12,6 +12,7 @@
 
 <ion-content padding>
   <div class="question-container">
+    <div>{{ currentQuestion.category }}</div>
     <h3 [innerHTML]="currentQuestion.question | Sanitize"></h3>
     <hr>
     <div *ngIf="answers.length > 0">
@@ -28,5 +29,4 @@
       </ion-grid>
     </div>
   </div>
-
 </ion-content>


### PR DESCRIPTION
This pull request adds the category to the top of the display, rather than the bottom. This was done because the category distracts from the answer selections at the bottom of the window. It looks like the following:

![image](https://user-images.githubusercontent.com/9803215/67998314-74d01580-fc2e-11e9-9b6a-ccbcdb845ded.png)
